### PR TITLE
ブックマーク画面：ログイン済、未済の共通化 #6

### DIFF
--- a/app/Http/Controllers/Bookmarks/BookmarkController.php
+++ b/app/Http/Controllers/Bookmarks/BookmarkController.php
@@ -98,10 +98,6 @@ class BookmarkController extends Controller
      */
     public function showCreateForm()
     {
-        if (Auth::id() === null) {
-            return redirect('/login');
-        }
-
         SEOTools::setTitle('ブックマーク作成');
 
         $master_categories = BookmarkCategory::query()->oldest('id')->get();
@@ -127,11 +123,6 @@ class BookmarkController extends Controller
      */
     public function create(CreateBookmarkRequest $request)
     {
-        if (Auth::guest()) {
-            // @note ここの処理はユーザープロフィールでも使われている
-            return redirect('/login');
-        }
-
         // 下記のサービスでも同様のことが実現できる
         // @see https://www.linkpreview.net/
         $previewClient = new Client($request->url);
@@ -170,11 +161,6 @@ class BookmarkController extends Controller
      */
     public function showEditForm(Request $request, int $id)
     {
-        if (Auth::guest()) {
-            // @note ここの処理はユーザープロフィールでも使われている
-            return redirect('/login');
-        }
-
         SEOTools::setTitle('ブックマーク編集');
 
         $bookmark = Bookmark::query()->findOrFail($id);
@@ -204,11 +190,6 @@ class BookmarkController extends Controller
      */
     public function update(Request $request, int $id)
     {
-        if (Auth::guest()) {
-            // @note ここの処理はユーザープロフィールでも使われている
-            return redirect('/login');
-        }
-
         Validator::make($request->all(), [
             'comment' => 'required|string|min:10|max:1000',
             'category' => 'required|integer|exists:bookmark_categories,id',
@@ -245,11 +226,6 @@ class BookmarkController extends Controller
      */
     public function delete(int $id)
     {
-        if (Auth::guest()) {
-            // @note ここの処理はユーザープロフィールでも使われている
-            return redirect('/login');
-        }
-
         $model = Bookmark::query()->findOrFail($id);
 
         if ($model->can_not_delete_or_edit) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,16 +21,16 @@ Auth::routes();
 Route::prefix('/bookmarks')->group(function () {
     Route::get('/', 'Bookmarks\BookmarkController@list');
     Route::get('/category/{category_id}', 'Bookmarks\BookmarkController@listCategory');
-    Route::post('/', 'Bookmarks\BookmarkController@create');
-    Route::put('/{id}', 'Bookmarks\BookmarkController@update');
-    Route::delete('/{id}', 'Bookmarks\BookmarkController@delete');
+    Route::post('/', 'Bookmarks\BookmarkController@create')->middleware('auth');
+    Route::put('/{id}', 'Bookmarks\BookmarkController@update')->middleware('auth');
+    Route::delete('/{id}', 'Bookmarks\BookmarkController@delete')->middleware('auth');
 });
 
 Route::prefix('/bookmark-create')->group(function () {
-    Route::get('/', 'Bookmarks\BookmarkController@showCreateForm');
+    Route::get('/', 'Bookmarks\BookmarkController@showCreateForm')->middleware('auth');
 });
 Route::prefix('/bookmark-edit')->group(function () {
-    Route::get('/{id}', 'Bookmarks\BookmarkController@showEditForm');
+    Route::get('/{id}', 'Bookmarks\BookmarkController@showEditForm')->middleware('auth');
 });
 
 Route::prefix('/user')->group(function () {


### PR DESCRIPTION
以下のルーティングに `->middleware('auth');` を追加し、各アクションに記述されていた条件分岐を削除。

```
・Route::post('/', 'Bookmarks\BookmarkController@create')
・Route::put('/{id}', 'Bookmarks\BookmarkController@update')
・Route::delete('/{id}', 'Bookmarks\BookmarkController@delete')
・Route::get('/', 'Bookmarks\BookmarkController@showCreateForm')
・Route::get('/{id}', 'Bookmarks\BookmarkController@showEditForm')
```